### PR TITLE
Fix calling ftdi_get_library_version on M1 Mac systems

### DIFF
--- a/pylibftdi/driver.py
+++ b/pylibftdi/driver.py
@@ -156,6 +156,10 @@ class Driver(object):
             self._fdll.ftdi_usb_get_strings.argtypes = (
                 c_void_p, c_void_p,
                 c_char_p, c_int, c_char_p, c_int, c_char_p, c_int)
+            # library versions <1.0 don't provide ftdi_get_library_version, so
+            # we need to check for it before setting the restype.
+            if hasattr(self._fdll, 'ftdi_get_library_version'):
+                self._fdll.ftdi_get_library_version.restype = ftdi_version_info
         return self._fdll
     _fdll = None
 
@@ -165,8 +169,7 @@ class Driver(object):
         :rtype: tuple (major, minor, micro, version_string, snapshot_string)
         """
         if hasattr(self.fdll, 'ftdi_get_library_version'):
-            version = ftdi_version_info()
-            self.fdll.ftdi_get_library_version(byref(version))
+            version = self.fdll.ftdi_get_library_version()
             return libftdi_version(version.major, version.minor, version.micro,
                                    version.version_str, version.snapshot_str)
         else:


### PR DESCRIPTION
## Background

I've been trying to get pylibftdi running on a new M1-based Macbook Pro, but I was getting a SIGBUS anytime I tried to open a device. I eventually tracked the issue down to a call to `ftdi_get_library_version`.

`ftdi_get_library_version` [returns a `ftdi_version_info` struct](https://www.intra2net.com/en/developer/libftdi/documentation/ftdi_8c.html#af4b4d11e33d946568efc64851ee8c7e5), but in pylibftdi, [it gets called as a void function that takes a pointer to an already-allocated `ftdi_version_info`](https://github.com/codedstructure/pylibftdi/blob/4662ebe069eefd5a89709d4165e3be808cad636c/pylibftdi/driver.py#L168-L169).

It was unclear to me how this code would have worked before though, so I dug into the X86-64 ABI. The relevant stuff is on page 22 of the [System V ABI for AMD64 doc](https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf). When a function returns a struct, it gets called with an implicit first argument, which is a pointer to memory allocated to hold that struct.

That is to say, on AMD64, the actual ABI for the two functions below is identical:

```
void ftdi_get_library_version(ftdi_version_info* output);
ftdi_version_info ftdi_get_library_version();
```

So on AMD64, the existing code "Just Works." I haven't dug up the right docs for Apple's M1 ABI, but this change fixes the SIGBUS problem, so I think it's probably fine 🤷‍♂️

## Test Plan

I've tested this on Python 3.9, with both Arm and X86-64 (run through Rosetta) interpreters, on macOS 12.0.1. 

### Before, Intel
```
$ file $(which python3)
/Users/wrigby/.virtualenvs/pylibftdi-intel/bin/python3: Mach-O 64-bit executable x86_64
$ python3 -m pylibftdi.examples.info
pylibftdi version     : 0.18.0
libftdi version       : libftdi_version(major=1, minor=5, micro=0, version_str=b'1.5', snapshot_str=b'unknown')
libftdi library name  : /usr/local/lib/libftdi1.dylib
libusb version        : libusb_version(major=1, minor=0, micro=24, nano=11584, rc=b'', describe=b'http://libusb.info')
libusb library name   : /usr/local/lib/libusb-1.0.dylib
Python version        : 3.9.7
OS platform           : macOS-12.0.1-x86_64-i386-64bit
```

### Before, Arm
```
$ file $(which python3)
/Users/wrigby/.virtualenvs/pylibftdi-arm/bin/python3: Mach-O 64-bit executable arm64
$ python3 -m pylibftdi.examples.info

[1]    68148 bus error  python3 -m pylibftdi.examples.info
```

### After, Intel
```
$ file $(which python3)
/Users/wrigby/.virtualenvs/pylibftdi-intel/bin/python3: Mach-O 64-bit executable x86_64
$ python3 -m pylibftdi.examples.info
pylibftdi version     : 0.18.0
libftdi version       : libftdi_version(major=1, minor=5, micro=0, version_str=b'1.5', snapshot_str=b'unknown')
libftdi library name  : /usr/local/lib/libftdi1.dylib
libusb version        : libusb_version(major=1, minor=0, micro=24, nano=11584, rc=b'', describe=b'http://libusb.info')
libusb library name   : /usr/local/lib/libusb-1.0.dylib
Python version        : 3.9.7
OS platform           : macOS-12.0.1-x86_64-i386-64bit
```

### After, Arm
```
$ file $(which python3)
/Users/wrigby/.virtualenvs/pylibftdi-arm/bin/python3: Mach-O 64-bit executable arm64
$ python3 -m pylibftdi.examples.info
pylibftdi version     : 0.18.0
libftdi version       : libftdi_version(major=0, minor=0, micro=0, version_str=None, snapshot_str=None)
libftdi library name  : /opt/homebrew/lib/libftdi1.dylib
libusb version        : libusb_version(major=1, minor=0, micro=24, nano=11584, rc=b'', describe=b'http://libusb.info')
libusb library name   : /opt/homebrew/lib/libusb-1.0.dylib
Python version        : 3.9.9
OS platform           : macOS-12.0.1-arm64-arm-64bit
```

## Further testing
If I get a chance, I have machines available to test on Python 3.7 (and possibly 2.7) on Linux (Debian Buster).