### PR TITLE
Add type hinting for device and driver modules

### DIFF
--- a/pylibftdi/bitbang.py
+++ b/pylibftdi/bitbang.py
@@ -7,9 +7,10 @@ See LICENSE file for details and (absence of) warranty
 pylibftdi: https://github.com/codedstructure/pylibftdi
 
 """
-from pylibftdi.device import Device
 
-from pylibftdi.driver import FtdiError, BITMODE_BITBANG
+from pylibftdi._base import FtdiError
+from pylibftdi.device import Device
+from pylibftdi.driver import BITMODE_BITBANG
 from ctypes import c_ubyte, byref
 
 ALL_OUTPUTS = 0xFF

--- a/pylibftdi/device.py
+++ b/pylibftdi/device.py
@@ -559,13 +559,15 @@ class Device(object):
                 break
         return ''.join(line_buffer)
 
-    def readlines(self, sizehint: Optional[int]=None) -> list[str|bytes]:
+    def readlines(self, sizehint: Optional[int]=None) -> list[str]:
         """
         readlines() for file-like compatibility.
         """
-        lines: list[str|bytes] = []
+        lines: list[str] = []
         if sizehint is not None:
             string_blob = self.read(sizehint)
+            if isinstance(string_blob, bytes):
+                string_blob = self.decoder.decode(string_blob)
             lines.extend(string_blob.splitlines())
 
         while True:

--- a/pylibftdi/device.py
+++ b/pylibftdi/device.py
@@ -549,10 +549,10 @@ class Device(object):
         line_buffer: list[str] = []
         while True:
             next_char = self.read(1)
+            if not isinstance(next_char, str):
+                raise TypeError(".readline() only works for mode='t'")
             if next_char == '' or (0 < size < len(line_buffer)):
                 break
-            if isinstance(next_char, bytes):
-                next_char = self.decoder.decode(next_char)
             line_buffer.append(next_char)
             if (len(line_buffer) >= lsl and
                     line_buffer[-lsl:] == list(os.linesep)):
@@ -566,8 +566,8 @@ class Device(object):
         lines: list[str] = []
         if sizehint is not None:
             string_blob = self.read(sizehint)
-            if isinstance(string_blob, bytes):
-                string_blob = self.decoder.decode(string_blob)
+            if not isinstance(string_blob, str):
+                raise TypeError(".readlines() only works for mode='t'")
             lines.extend(string_blob.splitlines())
 
         while True:

--- a/pylibftdi/device.py
+++ b/pylibftdi/device.py
@@ -7,6 +7,7 @@ See LICENSE file for details and (absence of) warranty
 pylibftdi: https://github.com/codedstructure/pylibftdi
 
 """
+from __future__ import annotations
 
 import os
 import sys
@@ -16,6 +17,7 @@ import itertools
 
 from ctypes import (byref, create_string_buffer, c_char_p,
                     c_void_p, Structure, cast, POINTER)
+from typing import Any, Iterable, Optional, no_type_check
 
 from pylibftdi._base import FtdiError
 from pylibftdi.driver import (
@@ -102,9 +104,9 @@ class Device(object):
     # defining softspace allows us to 'print' to this device
     softspace = 0
 
-    def __init__(self, device_id=None, mode="b",
-                 encoding="latin1", interface_select=None,
-                 device_index=0, **kwargs):
+    def __init__(self, device_id: Optional[str]=None, mode: str="b",
+                 encoding: str="latin1", interface_select: Optional[int]=None,
+                 device_index: int=0, **kwargs: Any) -> None:
         """
         Device([device_id[, mode, [OPTIONS ...]]) -> Device instance
 
@@ -157,7 +159,7 @@ class Device(object):
             if param in kwargs:
                 setattr(self, param, kwargs.pop(param))
 
-        self.driver = Driver(**kwargs)
+        self.driver: Driver = Driver(**kwargs)
         self.fdll = self.driver.fdll
         # device_id is an optional serial number of the requested device.
         self.device_id = device_id
@@ -189,12 +191,12 @@ class Device(object):
         if not self.lazy_open:
             self.open()
 
-    def __del__(self):
+    def __del__(self) -> None:
         """free the ftdi_context resource"""
         if self._opened:
             self.close()
 
-    def open(self):
+    def open(self) -> None:
         """
         open connection to a FTDI device
         """
@@ -265,7 +267,7 @@ class Device(object):
         self.ftdi_fn.ftdi_set_latency_timer(16)
         self._opened = True
 
-    def handle_open_error(self, errcode):
+    def handle_open_error(self, errcode: int) -> str:
         """
         return a (hopefully helpful) error message on a failed open()
         """
@@ -284,7 +286,7 @@ class Device(object):
         msg = "%s (%d)\n%s" % (self.get_error_string(), errcode, err_help)
         return msg
 
-    def _open_device(self):
+    def _open_device(self) -> int:
         """
         Actually open the target device
 
@@ -292,7 +294,7 @@ class Device(object):
         :rtype: int
         """
         # FTDI vendor/product ids required here.
-        res = None
+        res: int = -1
         for usb_vid, usb_pid in itertools.product(USB_VID_LIST, USB_PID_LIST):
             open_args = [byref(self.ctx), usb_vid, usb_pid,
                          0, 0, self.device_index]
@@ -314,7 +316,7 @@ class Device(object):
 
         return res
 
-    def close(self):
+    def close(self) -> None:
         """close our connection, free resources"""
         if self._opened:
             self.fdll.ftdi_usb_close(byref(self.ctx))
@@ -323,7 +325,7 @@ class Device(object):
         self._opened = False
 
     @property
-    def baudrate(self):
+    def baudrate(self) -> int:
         """
         get or set the baudrate of the FTDI device. Re-read after setting
         to ensure baudrate was accepted by the driver.
@@ -331,12 +333,12 @@ class Device(object):
         return self._baudrate
 
     @baudrate.setter
-    def baudrate(self, value):
+    def baudrate(self, value: int) -> None:
         result = self.fdll.ftdi_set_baudrate(byref(self.ctx), value)
         if result == 0:
             self._baudrate = value
 
-    def _read(self, length):
+    def _read(self, length: int) -> bytes:
         """
         actually do the low level reading
 
@@ -351,7 +353,7 @@ class Device(object):
 
         return byte_data
 
-    def read(self, length):
+    def read(self, length: int) -> str|bytes:
         """
         read(length) -> bytes/string of up to `length` bytes.
 
@@ -381,7 +383,7 @@ class Device(object):
         else:
             return self.decoder.decode(byte_data)
 
-    def _write(self, byte_data):
+    def _write(self, byte_data: bytes) -> int:
         """
         actually do the low level writing
 
@@ -390,13 +392,13 @@ class Device(object):
         :return: number of bytes written
         """
         buf = create_string_buffer(byte_data)
-        written = self.fdll.ftdi_write_data(byref(self.ctx),
+        written: int = self.fdll.ftdi_write_data(byref(self.ctx),
                                             byref(buf), len(byte_data))
         if written < 0:
             raise FtdiError(self.get_error_string())
         return written
 
-    def write(self, data):
+    def write(self, data: str|bytes) -> int:
         """
         write(data) -> count of bytes actually written
 
@@ -409,20 +411,19 @@ class Device(object):
         if not self._opened:
             raise FtdiError("write() on closed Device")
 
-        try:
-            byte_data = bytes(data)
-        except TypeError:
-            # this will happen if we are Python3 and data is a str.
-            byte_data = self.encoder.encode(data)
+        if not isinstance(data, bytes):
+            data = self.encoder.encode(data)
+
+        assert isinstance(data, bytes)
 
         # actually write it
         if self.chunk_size != 0:
-            remaining = len(byte_data)
+            remaining = len(data)
             written = 0
             while remaining > 0:
                 start = written
                 length = min(remaining, self.chunk_size)
-                result = self._write(byte_data[start: start + length])
+                result = self._write(data[start: start + length])
                 if result == 0:
                     # don't continue to try writing forever if nothing
                     # is actually being written
@@ -431,10 +432,10 @@ class Device(object):
                     written += result
                     remaining -= result
         else:
-            written = self._write(byte_data)
+            written = self._write(data)
         return written
 
-    def flush(self, flush_what=FLUSH_BOTH):
+    def flush(self, flush_what: int=FLUSH_BOTH) -> None:
         """
         Instruct the FTDI device to flush its FIFO buffers
 
@@ -461,26 +462,26 @@ class Device(object):
             msg = "%s (%d)" % (self.get_error_string(), res)
             raise FtdiError(msg)
 
-    def flush_input(self):
+    def flush_input(self) -> None:
         """
         flush the device input buffer
         """
         self.flush(FLUSH_INPUT)
 
-    def flush_output(self):
+    def flush_output(self) -> None:
         """
         flush the device output buffer
         """
         self.flush(FLUSH_OUTPUT)
 
-    def get_error_string(self):
+    def get_error_string(self) -> str:
         """
         :return: error string from libftdi driver
         """
-        return self.fdll.ftdi_get_error_string(byref(self.ctx))
+        return str(self.fdll.ftdi_get_error_string(byref(self.ctx)))
 
     @property
-    def ftdi_fn(self):
+    def ftdi_fn(self): # type: ignore
         """
         this allows the vast majority of libftdi functions
         which are called with a pointer to a ftdi_context
@@ -498,12 +499,13 @@ class Device(object):
         # fdll and ctx objects in the closure are up-to-date, though.
         class FtdiForwarder(object):
 
-            def __getattr__(innerself, key):
+            @no_type_check
+            def __getattr__(innerself, key: str):
                 return functools.partial(getattr(self.fdll, key),
                                          byref(self.ctx))
         return FtdiForwarder()
 
-    def __enter__(self):
+    def __enter__(self) -> Device:
         """
         support for context manager.
 
@@ -517,7 +519,8 @@ class Device(object):
         self.open()
         return self
 
-    def __exit__(self, exc_type, exc_val, tb):
+    @no_type_check
+    def __exit__(self, exc_type, exc_val, tb) -> None:
         """support for context manager"""
         self.close()
 
@@ -527,13 +530,13 @@ class Device(object):
     #
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """
         The Python file API defines a read-only 'closed' attribute
         """
         return not self._opened
 
-    def readline(self, size=0):
+    def readline(self, size: int=0) -> str:
         """
         readline() for file-like compatibility.
 
@@ -543,22 +546,24 @@ class Device(object):
         This only works for mode='t' on Python3
         """
         lsl = len(os.linesep)
-        line_buffer = []
+        line_buffer: list[str] = []
         while True:
             next_char = self.read(1)
             if next_char == '' or (0 < size < len(line_buffer)):
                 break
+            if isinstance(next_char, bytes):
+                next_char = self.decoder.decode(next_char)
             line_buffer.append(next_char)
             if (len(line_buffer) >= lsl and
                     line_buffer[-lsl:] == list(os.linesep)):
                 break
         return ''.join(line_buffer)
 
-    def readlines(self, sizehint=None):
+    def readlines(self, sizehint: Optional[int]=None) -> list[str|bytes]:
         """
         readlines() for file-like compatibility.
         """
-        lines = []
+        lines: list[str|bytes] = []
         if sizehint is not None:
             string_blob = self.read(sizehint)
             lines.extend(string_blob.splitlines())
@@ -570,7 +575,7 @@ class Device(object):
             lines.append(line)
         return lines
 
-    def writelines(self, lines):
+    def writelines(self, lines: list[str|bytes]) -> None:
         """
         writelines for file-like compatibility.
 
@@ -579,10 +584,10 @@ class Device(object):
         for line in lines:
             self.write(line)
 
-    def __iter__(self):
+    def __iter__(self) -> Device:
         return self
 
-    def __next__(self):
+    def __next__(self) -> str:
         while True:
             line = self.readline()
             if line:

--- a/pylibftdi/driver.py
+++ b/pylibftdi/driver.py
@@ -72,18 +72,19 @@ class Driver(object):
     We load the libftdi library, and use it.
     """
 
-    # prefer libftdi1 if available. Windows uses 'lib' prefix.
-    _lib_search: dict[str, list[str]] = {
-        'libftdi': ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'],
-        'libusb': ['usb-1.0', 'libusb-1.0']
-    }
-
     def __init__(self, libftdi_search: Optional[str|list[str]]=None, **kwargs: dict[str, Any]) -> None:
         """
         :param libftdi_search: force a particular version of libftdi to be used
             can specify either library name(s) or path(s)
         :type libftdi_search: string or a list of strings
         """
+        # The default libraries if None is specified.
+        # Prefer libftdi1 if available. Windows uses 'lib' prefix.
+        self._lib_search = {
+            'libftdi': ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'],
+            'libusb': ['usb-1.0', 'libusb-1.0']
+        }
+
         if isinstance(libftdi_search, str):
             self._lib_search['libftdi'] = [libftdi_search]
         elif isinstance(libftdi_search, list):

--- a/pylibftdi/driver.py
+++ b/pylibftdi/driver.py
@@ -7,6 +7,7 @@ See LICENSE file for details and (absence of) warranty
 pylibftdi: https://github.com/codedstructure/pylibftdi
 
 """
+from __future__ import annotations
 
 import itertools
 from collections import namedtuple

--- a/pylibftdi/driver.py
+++ b/pylibftdi/driver.py
@@ -72,19 +72,20 @@ class Driver(object):
     We load the libftdi library, and use it.
     """
 
+    # The default library names to search for. This can be overridden by
+    # passing a library name or list of library names to the constructor.
+    # Prefer libftdi1 if available. Windows uses 'lib' prefix.
+    _lib_search = {
+        'libftdi': ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'],
+        'libusb': ['usb-1.0', 'libusb-1.0']
+    }
+
     def __init__(self, libftdi_search: Optional[str|list[str]]=None, **kwargs: dict[str, Any]) -> None:
         """
         :param libftdi_search: force a particular version of libftdi to be used
             can specify either library name(s) or path(s)
         :type libftdi_search: string or a list of strings
         """
-        # The default libraries if None is specified.
-        # Prefer libftdi1 if available. Windows uses 'lib' prefix.
-        self._lib_search = {
-            'libftdi': ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'],
-            'libusb': ['usb-1.0', 'libusb-1.0']
-        }
-
         if isinstance(libftdi_search, str):
             self._lib_search['libftdi'] = [libftdi_search]
         elif isinstance(libftdi_search, list):

--- a/pylibftdi/driver.py
+++ b/pylibftdi/driver.py
@@ -98,25 +98,25 @@ class Driver(object):
         self._fdll: Any = None
         self._libusb_dll: Any = None
 
-    def _load_library(self, name: str, search_list: Optional[str]=None) -> Any:
+    def _load_library(self, name: str, search_list: Optional[list[str]]=None) -> Any:
         """
         find and load the requested library
 
         :param name: library name
-        :param search_list: string referring to library names
+        :param search_list: an optional list of strings referring to library names
             library names or paths can be given
         :return: a CDLL object referring to the requested library
         """
-        # If no search list is given, use the default.
-        if not isinstance(search_list, str):
-            raise TypeError(f'library search list must be a string, not {type(search_list)}')
+        # If no search list is given, use the default library names stored in self._lib_search.
         if search_list is None:
-            libraries = self._lib_search.get(name, "")
+            search_list = self._lib_search.get(name, [])
+        elif isinstance(search_list, list):
+            search_list = search_list
         else:
-            libraries = [search_list]
+            raise TypeError(f'search_list type should be list[str], not {type(search_list)}')
 
         lib = None
-        for dll in libraries:
+        for dll in search_list:
             try:
                 # Windows in particular can have find_library
                 # not find things which work fine directly on

--- a/pylibftdi/driver.py
+++ b/pylibftdi/driver.py
@@ -78,14 +78,19 @@ class Driver(object):
         'libusb': ['usb-1.0', 'libusb-1.0']
     }
 
-    def __init__(self, libftdi_search: Optional[str]=None, **kwargs: dict[str, Any]) -> None:
+    def __init__(self, libftdi_search: Optional[str|list[str]]=None, **kwargs: dict[str, Any]) -> None:
         """
         :param libftdi_search: force a particular version of libftdi to be used
             can specify either library name(s) or path(s)
-        :type libftdi_search: string or sequence of strings
+        :type libftdi_search: string or a list of strings
         """
-        if libftdi_search is not None:
-            self._lib_search['libftdi'] = list(libftdi_search)
+        if isinstance(libftdi_search, str):
+            self._lib_search['libftdi'] = [libftdi_search]
+        elif isinstance(libftdi_search, list):
+            self._lib_search['libftdi'] = libftdi_search
+        elif libftdi_search is not None:
+            raise TypeError(f'libftdi_search type should be ' \
+                            f'Optional[str|list[str]], not {type(libftdi_search)}')
 
         # Library handles.
         self._fdll: Any = None

--- a/pylibftdi/driver.py
+++ b/pylibftdi/driver.py
@@ -77,7 +77,7 @@ class Driver(object):
         'libusb': ('usb-1.0', 'libusb-1.0')
     }
 
-    def __init__(self, libftdi_search=None, **kwargs):
+    def __init__(self, libftdi_search=None, **kwargs) -> None:
         """
         :param libftdi_search: force a particular version of libftdi to be used
             can specify either library name(s) or path(s)
@@ -163,7 +163,7 @@ class Driver(object):
         return self._fdll
     _fdll = None
 
-    def libftdi_version(self):
+    def libftdi_version(self) -> libftdi_version:
         """
         :return: the version of the underlying library being used
         :rtype: tuple (major, minor, micro, version_string, snapshot_string)
@@ -178,7 +178,7 @@ class Driver(object):
                                    '< 1.0 - no ftdi_get_library_version()',
                                    'unknown')
 
-    def list_devices(self):
+    def list_devices(self) -> list[tuple]:
         """
         :return: (manufacturer, description, serial#) for each attached
             device, e.g.:

--- a/pylibftdi/driver.py
+++ b/pylibftdi/driver.py
@@ -110,9 +110,7 @@ class Driver(object):
         # If no search list is given, use the default library names stored in self._lib_search.
         if search_list is None:
             search_list = self._lib_search.get(name, [])
-        elif isinstance(search_list, list):
-            search_list = search_list
-        else:
+        elif not isinstance(search_list, list):
             raise TypeError(f'search_list type should be list[str], not {type(search_list)}')
 
         lib = None

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,16 @@ setup_args = dict(
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development :: Embedded Systems",
         "Topic :: System :: Hardware"
-    ]
+    ],
+    python_requires=">=3.7"
 )
 
 setup(**setup_args)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -82,7 +82,6 @@ class MockDriver(object):
 
 
 # importing this _does_ things...
-pylibftdi.driver.Driver = MockDriver
 pylibftdi.device.Driver = MockDriver
 
 from pylibftdi.device import Device

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -80,11 +80,25 @@ class LoopbackTest(unittest.TestCase):
         self.assertEqual(d.readline(), 'Hello World\n')
         self.assertEqual(d.readline(), 'Bye')
 
+    def testPrintBytes(self):
+        d = LoopDevice(mode='t')
+        d.write(b'Hello')
+        d.write(b' World\n')
+        d.write(b'Bye')
+        self.assertEqual(d.readline(), 'Hello World\n')
+        self.assertEqual(d.readline(), 'Bye')
+
     def testLines(self):
         d = LoopDevice(mode='t')
         lines = ['Hello\n', 'World\n', 'And\n', 'Goodbye\n']
         d.writelines(lines)
         self.assertEqual(d.readlines(), lines)
+
+    def testLinesBytes(self):
+        d = LoopDevice(mode='t')
+        lines = [b'Hello\n', b'World\n', b'And\n', b'Goodbye\n']
+        d.writelines(lines)
+        self.assertEqual(d.readlines(), [str(l, 'ascii') for l in lines])
 
     def testIterate(self):
         d = LoopDevice(mode='t')

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -115,6 +115,25 @@ class LoopbackTest(unittest.TestCase):
         self.assertEqual(d.readline(), 'Hello World\n')
         self.assertEqual(d.readline(), 'Bye')
 
+    def testReadLineBytes(self):
+        """
+        Device.readline() when in byte mode should raise a TypeError.
+        This method should only be used in text mode.
+        """
+        d = LoopDevice(mode='b')
+        d.write(b'Hello\n')
+        with self.assertRaises(TypeError):
+            d.readline()
+
+    def testReadLinesBytes(self):
+        """
+        Device.readlines() when in byte mode should raise a TypeError.
+        This method should only be used in text mode.
+        """
+        d = LoopDevice(mode='b')
+        d.write(b'Hello\n')
+        with self.assertRaises(TypeError):
+            d.readlines()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -9,13 +9,24 @@ pylibftdi: https://github.com/codedstructure/pylibftdi
 This module contains some basic tests for Driver class.
 """
 
-import unittest
+from tests.test_common import unittest
 from pylibftdi.driver import Driver
 
 class DriverTest(unittest.TestCase):
     """
     Test to ensure the Driver class accepts the correct arguments. 
     """
+
+    def setUp(self):
+        """The default library names are stored in the Driver class as a
+        class variable. This method will run before each unit test to reset
+        the default library names. If other class variables are added to the
+        Driver class, they should also be added here.
+        """
+        Driver._lib_search = {
+            'libftdi': ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'],
+            'libusb': ['usb-1.0', 'libusb-1.0']
+        }
 
     def testNoneLibrary(self):
         """

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,0 +1,70 @@
+"""
+pylibftdi - python wrapper for libftdi
+
+Copyright (c) 2010-2014 Ben Bass <benbass@codedstructure.net>
+See LICENSE file for details and (absence of) warranty
+
+pylibftdi: https://github.com/codedstructure/pylibftdi
+
+This module contains some basic tests for Driver class.
+"""
+
+import unittest
+from pylibftdi.driver import Driver
+
+class DriverTest(unittest.TestCase):
+    """
+    Test to ensure the Driver class accepts the correct arguments. 
+    """
+
+    def setUp(self):
+        """The default library names are stored in the Driver class as a
+        class variable. This method will run before each unit test to reset
+        the default library names. If other class variables are added to the
+        Driver class, they should also be added here.
+        """
+        Driver._lib_search = {
+            'libftdi': ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'],
+            'libusb': ['usb-1.0', 'libusb-1.0']
+        }
+
+    def testNoneLibrary(self):
+        """
+        The Driver class can accept no library names passed in to
+        the constructor. This uses the default libraries specified in the
+        Driver class. This is the default and most typical behavior.
+        """
+        driver1 = Driver(libftdi_search=None)
+        self.assertListEqual(driver1._lib_search['libftdi'], \
+                        ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'])
+
+    def testNoExplicitParameters(self):
+        """
+        The Driver class can accept no explicit parameters. Ensures 
+        that libftdi_search is set to None by default.
+        """
+        driver = Driver()
+        self.assertListEqual(driver._lib_search['libftdi'], \
+                        ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'])
+
+    def testStringLibrary(self):
+        """
+        The Driver class can accept a string library name and store the
+        value in a list with a single element. You might use this when you
+        know the exact name of the library (perhaps custom).
+        """
+        driver = Driver(libftdi_search='libftdi')
+        self.assertListEqual(driver._lib_search['libftdi'], ['libftdi'])
+
+    def testListLibrary(self):
+        """
+        The Driver class can accept a list of library names and store the
+        values in a list. You might use this to support a limited number of
+        platforms with different library names.
+        """
+        driver = Driver(libftdi_search=['ftdi1', 'libftdi1'])
+        self.assertListEqual(driver._lib_search['libftdi'], ['ftdi1', 'libftdi1'])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -9,6 +9,7 @@ pylibftdi: https://github.com/codedstructure/pylibftdi
 This module contains some basic tests for Driver class.
 """
 
+from pylibftdi import LibraryMissingError
 from tests.test_common import unittest
 from pylibftdi.driver import Driver
 
@@ -65,6 +66,42 @@ class DriverTest(unittest.TestCase):
         driver = Driver(libftdi_search=['ftdi1', 'libftdi1'])
         self.assertListEqual(driver._lib_search['libftdi'], ['ftdi1', 'libftdi1'])
 
+    def testLoadLibrarySearchListEmpty(self):
+        """
+        If a Driver object calls _load_library where search_list is an empty
+        list, LibraryMissingError will be raised.
+        """
+        # Use the default library names.
+        driver = Driver(libftdi_search=None)
+        # Try and find the library names for libftdi.
+        with self.assertRaises(expected_exception=LibraryMissingError):
+            driver._load_library(name='libftdi', search_list=[])
+    
+    def testLoadLibraryMissingLibraryName(self):
+        """
+        If a Driver object calls _load_library with with a name not in the
+        default library names (Driver._lib_search), LibraryMissingError will
+        be raised.
+        """
+        driver = Driver(libftdi_search=None)
+        with self.assertRaises(expected_exception=LibraryMissingError):
+            driver._load_library(name='non-existent-library', search_list=None)
+
+    def testLoadLibrarySearchListNone(self):
+        """
+        If a Driver object calls _load_library with with a valid name (the key
+        exists in Driver._lib_search) and search_list is None, the proper
+        library will be returned.
+        """
+        driver = Driver(libftdi_search=None)
+        try:
+            # Assert that Driver can find both of the defaults.
+            libftdi = driver._load_library(name='libftdi', search_list=None)
+            libusb = driver._load_library(name='libusb', search_list=None)
+            self.assertIsNotNone(obj=libftdi, msg='libftdi library not found')
+            self.assertIsNotNone(obj=libusb, msg='libusb library not found')
+        except LibraryMissingError:
+            self.fail('LibraryMissingError raised for default library names.')
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -17,25 +17,14 @@ class DriverTest(unittest.TestCase):
     Test to ensure the Driver class accepts the correct arguments. 
     """
 
-    def setUp(self):
-        """The default library names are stored in the Driver class as a
-        class variable. This method will run before each unit test to reset
-        the default library names. If other class variables are added to the
-        Driver class, they should also be added here.
-        """
-        Driver._lib_search = {
-            'libftdi': ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'],
-            'libusb': ['usb-1.0', 'libusb-1.0']
-        }
-
     def testNoneLibrary(self):
         """
         The Driver class can accept no library names passed in to
         the constructor. This uses the default libraries specified in the
         Driver class. This is the default and most typical behavior.
         """
-        driver1 = Driver(libftdi_search=None)
-        self.assertListEqual(driver1._lib_search['libftdi'], \
+        driver = Driver(libftdi_search=None)
+        self.assertListEqual(driver._lib_search['libftdi'], \
                         ['ftdi1', 'libftdi1', 'ftdi', 'libftdi'])
 
     def testNoExplicitParameters(self):


### PR DESCRIPTION
I'm using a downstream application of this library and got curious how the strings and bytes were handled differently in the Device class. I added some type hints for my own edification that adheres to `mypy --strict`. I also added a couple test cases to ensure it is behaving as intended when using bytes.