### PR TITLE
fix pylibftdi for Python3.12

### DIFF
--- a/.github/workflows/python-lint-and-test.yml
+++ b/.github/workflows/python-lint-and-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # Note we don't test version 3.7 as many dev deps require >= 3.8
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Embedded Systems",
     "Topic :: System :: Hardware",

--- a/src/pylibftdi/driver.py
+++ b/src/pylibftdi/driver.py
@@ -143,7 +143,8 @@ class Driver:
                 # cdll access.
                 lib = getattr(cdll, dll)
                 break
-            except OSError:
+            # On DLL load fail, Python <3.12 raises OSError, 3.12+ AttributeError.
+            except (OSError, AttributeError):
                 lib_path = find_library(dll)
                 if lib_path is not None:
                     lib = getattr(cdll, lib_path)


### PR DESCRIPTION
Address issue #7 - previously pylibftdi failed to load the driver when run with Python3.12

This seems to be a change to the behaviour of `ctypes.cdll`; previous to 3.12 this would raise an `OSError` when given an unloadable library as an attribute, in 3.12+ it seems to raise an `AttributeError`.