### PR TITLE
fix bitbang port value exceeding 8 bits

### DIFF
--- a/src/pylibftdi/bitbang.py
+++ b/src/pylibftdi/bitbang.py
@@ -158,7 +158,9 @@ class BitBangDevice(Device):
 
     @port.setter
     def port(self, value):
+        # restrict to a single byte
+        value &= 0xFF
         self._latch = value
         if self.sync:
             self.flush_output()
-        return super().write(chr(value))
+        return super().write(value.to_bytes())

--- a/src/pylibftdi/bitbang.py
+++ b/src/pylibftdi/bitbang.py
@@ -163,4 +163,5 @@ class BitBangDevice(Device):
         self._latch = value
         if self.sync:
             self.flush_output()
-        return super().write(value.to_bytes())
+        # note to_bytes() gets these as default args in Python3.11+
+        return super().write(value.to_bytes(1, "big"))


### PR DESCRIPTION
Fixes issue #6 - bitbang port values could exceed 8 bits, which would cause unhandled exceptions.

This change causes the port to behave like a hardware 8 bit register, i.e. it silently keeps the low 8 bits only.