### PR TITLE
Fix: flush() now calls libftdi(>= 1.5) `tc[io]flush` functions.

### DIFF
--- a/src/pylibftdi/device.py
+++ b/src/pylibftdi/device.py
@@ -493,16 +493,18 @@ class Device:
             `FLUSH_INPUT` (just the rx buffer);
             `FLUSH_OUTPUT` (just the tx buffer)
         """
+
         if flush_what == FLUSH_BOTH:
-            fn = self.fdll.ftdi_usb_purge_buffers
+            fn = self.fdll.ftdi_tcioflush
         elif flush_what == FLUSH_INPUT:
-            fn = self.fdll.ftdi_usb_purge_rx_buffer
+            fn = self.fdll.ftdi_tciflush
         elif flush_what == FLUSH_OUTPUT:
-            fn = self.fdll.ftdi_usb_purge_tx_buffer
+            fn = self.fdll.ftdi_tcoflush
         else:
             raise ValueError(
                 f"Invalid value passed to {self.__class__.__name__}.flush()"
             )
+
         res = fn(byref(self.ctx))
         if res != 0:
             msg = "%s (%d)" % (self.get_error_string(), res)

--- a/tests/test_bitbang.py
+++ b/tests/test_bitbang.py
@@ -121,11 +121,11 @@ class BitBangFunctions(CallCheckMixin, unittest.TestCase):
         self.assertCallsExact(
             x,
             [
-                "ftdi_usb_purge_tx_buffer",
+                "ftdi_tcoflush",
                 "ftdi_write_data",
-                "ftdi_usb_purge_tx_buffer",
+                "ftdi_tcoflush",
                 "ftdi_write_data",
-                "ftdi_usb_purge_tx_buffer",
+                "ftdi_tcoflush",
                 "ftdi_write_data",
             ],
         )
@@ -155,10 +155,10 @@ class BitBangFunctions(CallCheckMixin, unittest.TestCase):
             dev.port |= 2
 
         self.assertCallsExact(
-            _1, ["ftdi_read_pins", "ftdi_usb_purge_tx_buffer", "ftdi_write_data"]
+            _1, ["ftdi_read_pins", "ftdi_tcoflush", "ftdi_write_data"]
         )
         self.assertCallsExact(
-            _2, ["ftdi_read_pins", "ftdi_usb_purge_tx_buffer", "ftdi_write_data"]
+            _2, ["ftdi_read_pins", "ftdi_tcoflush", "ftdi_write_data"]
         )
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -62,9 +62,9 @@ class DeviceFunctions(CallCheckMixin, unittest.TestCase):
 
     def testFlush(self):
         with Device() as dev:
-            self.assertCalls(dev.flush_input, "ftdi_usb_purge_rx_buffer")
-            self.assertCalls(dev.flush_output, "ftdi_usb_purge_tx_buffer")
-            self.assertCalls(dev.flush, "ftdi_usb_purge_buffers")
+            self.assertCalls(dev.flush_input, "ftdi_tciflush")
+            self.assertCalls(dev.flush_output, "ftdi_tcoflush")
+            self.assertCalls(dev.flush, "ftdi_tcioflush")
 
     def testClose(self):
         d = Device()


### PR DESCRIPTION
flush() now calls libftdi >= 1.5 `tc[io]flush` functions.
Closes #13 